### PR TITLE
Remove '/' from imu frame_id.

### DIFF
--- a/launch/mti10.launch.xml
+++ b/launch/mti10.launch.xml
@@ -4,7 +4,7 @@
     <arg name="baudrate" default="115200"/>
     <arg name="timeout" default="0.002"/>
     <arg name="initial_wait" default="0.1"/>
-    <arg name="frame_id" default="/imu"/>
+    <arg name="frame_id" default="imu"/>
     <arg name="frame_local" default="ENU"/>
     <arg name="no_rotation_duration" default="0"/>
     <arg name="angular_velocity_covariance_diagonal" default="[0.0004, 0.0004, 0.0004]"/>


### PR DESCRIPTION
In ROS 2, tf2 frame_ids cannot start with a '/'